### PR TITLE
Improve position stats performance

### DIFF
--- a/src/main/scala/positionStats.scala
+++ b/src/main/scala/positionStats.scala
@@ -15,14 +15,14 @@ case object positionStats {
 
   val positionDataWithMax: Position => Iterator[Seq[PSymbol]] => Seq[PositionData] =
     maxPos => seqs =>
-      seqs.foldLeft[Seq[PositionData]]( Seq.fill(maxPos)(initialPositionData) ) {
-        (acc: Seq[PositionData], seq) =>
-          seq.zipWithIndex.foldLeft[Seq[PositionData]](acc) {
+      seqs.foldLeft[collection.mutable.Seq[PositionData]]( collection.mutable.Seq.fill(maxPos)(initialPositionData) ) {
+        (acc: collection.mutable.Seq[PositionData], seq) =>
+          seq.zipWithIndex.foldLeft[collection.mutable.Seq[PositionData]](acc) {
             case (pdatas, (PSymbol(char, errProb), pos)) => {
 
               val pdata = pdatas(pos)
 
-              pdatas.updated(
+              pdatas.update(
                 pos,
                 PositionData(
                   number            = 1 + pdata.number                                    ,
@@ -34,9 +34,11 @@ case object positionStats {
                   Ns                = if(char.toUpper == 'N') pdata.Ns + 1 else pdata.Ns
                 )
               )
+
+              pdatas
             }
           }
-      }
+      } toList
 
   case class PositionData(
     val number            : BigInt,

--- a/src/test/scala/PositionStats.scala
+++ b/src/test/scala/PositionStats.scala
@@ -26,10 +26,9 @@ class PositionStats extends org.scalatest.FunSuite {
     }
 
   // approx 4min on a std laptop
-  ignore("calculate position stats") {
+  test("calculate position stats") {
 
     println(s"in position stats")
-    println("\n")
 
     val in_stats =
       positionStats.positionDataWithMax(250)( inReads.map(_.sequence.pSymbols) )
@@ -37,7 +36,6 @@ class PositionStats extends org.scalatest.FunSuite {
     in_stats.zipWithIndex foreach show
 
     println(s"out position stats")
-    println("\n")
 
     val out_stats =
       positionStats.positionDataWithMax(250)( outReads.map(_.sequence.pSymbols) )


### PR DESCRIPTION
Right now this takes `140s` for`~140000` reads with length `250`, so in reads per second we do approx `1000/s`. This should be faster.

The obvious lies in using a mutable seq for accumulating numbers per position.